### PR TITLE
Fix version for build

### DIFF
--- a/libxmp/version.py
+++ b/libxmp/version.py
@@ -38,5 +38,5 @@ Version information for libxmp.
 
 # Do not change the format of this next line!  Doing so risks breaking
 # setup.py
-VERSION_TUPLE = (2, 0, 1)
-VERSION = ".".join(str(x) for x in VERSION_TUPLE)
+VERSION = "2.0.1"
+VERSION_TUPLE = tuple(map(int, VERSION.split(".")))


### PR DESCRIPTION
Fix the build for now as `setup.py` assumes that `VERSION` is a hardcoded string.